### PR TITLE
Change RH64 Lockstep's name

### DIFF
--- a/core/assets/sounds/cues/lockstep64/data.json
+++ b/core/assets/sounds/cues/lockstep64/data.json
@@ -1,6 +1,6 @@
 {
   "gameID": "lockstep64",
-  "gameName": "RH64 Lockstep",
+  "gameName": "Lockstep (RH64)",
   "cues": [
     {
       "id": "lockstep64/yah",


### PR DESCRIPTION
>to Lockstep (RH64)

### Prerequisites
* [x] I have read and understood the [contribution guidelines](CONTRIBUTING.md)
* [x] This pull request follows the code style of the project
*  I have tested this feature thoroughly WITH THE USE of the load-all-sounds starter
  _no need_

**Issues Fixed:** 
RH64's Lockstep name

