### PR TITLE
Improve Karate Man GBA

### DIFF
--- a/core/assets/sounds/cues/karateManGba/data.json
+++ b/core/assets/sounds/cues/karateManGba/data.json
@@ -4,75 +4,75 @@
   "series": "tengoku",
   "cues": [
     {
+      "id": "karateManGba/ohYeah",
+      "duration": 0.5,
+      "name": "oh yeah!"
+    },
+    {
       "id": "karateManGba/potOut",
-      "duration": 1,
-      "name": "pot - out"
+      "duration": 0.5,
+      "name": "out"
     },
     {
       "id": "karateManGba/potHit",
-      "duration": 1,
-      "name": "pot - hit"
+      "duration": 0.5,
+      "name": "hit"
     },
     {
       "id": "karateManGba/potHitHighFlow",
-      "duration": 1,
-      "name": "pot - hit (high flow)"
+      "duration": 0.5,
+      "name": "pot - hit"
     },
     {
       "id": "karateManGba/potBreak",
-      "duration": 1,
+      "duration": 0.5,
       "name": "pot - break"
     },
-    {
-      "id": "karateManGba/rockHit",
-      "duration": 1,
-      "name": "rock - hit"
-    },
-    {
+	{
       "id": "karateManGba/soccerHit",
-      "duration": 1,
+      "duration": 0.5,
       "name": "soccer ball - hit"
     },
     {
       "id": "karateManGba/soccerBreak",
-      "duration": 1,
+      "duration": 0.5,
       "name": "soccer ball - break"
     },
-    {
+	{
       "id": "karateManGba/lightbulbHit",
-      "duration": 1,
+      "duration": 0.5,
       "name": "lightbulb - hit"
     },
     {
       "id": "karateManGba/lightbulbBreak",
-      "duration": 1,
+      "duration": 0.5,
       "name": "lightbulb - break"
     },
     {
+      "id": "karateManGba/rockHit",
+      "duration": 0.5,
+      "name": "rock - hit"
+    },
+    {
       "id": "karateManGba/bombHit",
-      "duration": 1,
+      "duration": 0.5,
       "name": "bomb - hit"
     },
     {
       "id": "karateManGba/bombBreak",
-      "duration": 1,
+      "duration": 0.5,
       "name": "bomb - break"
     },
     {
-      "id": "karateManGba/ohYeah",
-      "duration": 1,
-      "name": "oh yeah!"
-    },
-    {
       "id": "karateManGba/gongSerious",
-      "duration": 1,
-      "name": "serious mode"
+      "duration": 0.5,
+      "name": "gong - serious mode"
     }
   ],
   "patterns": [
     {
       "id": "karateManGba_pot",
-      "name": "pot",
+      "name": "hit - low nori",
       "cues": [
         {
           "id": "karateManGba/potOut",
@@ -86,7 +86,7 @@
     },
     {
       "id": "karateManGba_potHighFlow",
-      "name": "pot (high flow)",
+      "name": "pot",
       "cues": [
         {
           "id": "karateManGba/potOut",
@@ -135,20 +135,6 @@
       ]
     },
     {
-      "id": "karateManGba_remix8",
-      "name": "gong",
-      "cues": [
-        {
-          "id": "karateManGba/potOut",
-          "beat": 0
-        },
-        {
-          "id": "karateManGba/gongSerious",
-          "beat": 1
-        }
-      ]
-    },
-    {
       "id": "karateManGba_lightbulb",
       "name": "lightbulb",
       "cues": [
@@ -181,6 +167,20 @@
         {
           "id": "karateManGba/bombBreak",
           "beat": 2
+        }
+      ]
+    },
+	{
+      "id": "karateManGba_remix8",
+      "name": "gong - serious mode",
+      "cues": [
+        {
+          "id": "karateManGba/potOut",
+          "beat": 0
+        },
+        {
+          "id": "karateManGba/gongSerious",
+          "beat": 1
         }
       ]
     }


### PR DESCRIPTION
### Prerequisites
* [X] I have read and understood the [contribution guidelines](CONTRIBUTING.md)
* [X] This pull request follows the code style of the project
* [X] I have tested this feature thoroughly WITH THE USE of the load-all-sounds starter (I didn't make any new IDs, so force load would be a bit of an overkill)
  * ![capture](https://user-images.githubusercontent.com/25730122/27891739-1b277d02-61c1-11e7-88cb-3e8ecdde85d4.PNG)
* [X] This pull request is merging into **`dev`**
* [X] I have filled out this pull request template knowing if I remove it the pull request will immediately become invalid and will be closed

### Changes Proposed in this Pull Request
I made a data.json with a few changes to Karate Man GBA.
First and foremost, name changes.
cues:
"pot - out" > "out"
"pot - hit" > "hit"
"pot - hit (high flow)" > "pot - hit"
"serious mode" > "gong - serious mode"
All other cues keep their names.
patterns:
"pot" > "hit - low nori"
"pot (high flow) > "pot"
"gong" > "gong - serious mode"
All other patterns keep their names.
Also, every cue is now one half beat long. Now you can stick an "oh yeah!" between two objects.
The last more minor change is cue rearrangement.
"oh yeah!" is now at the top of the cue list.
The heavy objects are below the light objects, followed by the serious mode gong.
Similar changes have been made to the pattern list.