### PR TITLE
Cue earliness

### DIFF
--- a/core/src/main/kotlin/io/github/chrislo27/rhre3/registry/GameRegistry.kt
+++ b/core/src/main/kotlin/io/github/chrislo27/rhre3/registry/GameRegistry.kt
@@ -377,7 +377,7 @@ object GameRegistry : Disposable {
                                 baseFileHandle.child("$objID.${obj.fileExtension}"),
                                 obj.introSound?.starSubstitution(), obj.endingSound?.starSubstitution(),
                                 obj.responseIDs.starSubstitution(),
-                                obj.baseBpm, obj.loops)
+                                obj.baseBpm, obj.loops, obj.earliness)
                         is EquidistantObject ->
                             Equidistant(game, objID, obj.deprecatedIDs,
                                         obj.name, obj.distance,
@@ -435,7 +435,7 @@ object GameRegistry : Disposable {
                     val name = if (!loops) fh.nameWithoutExtension() else (fh.nameWithoutExtension().substringBeforeLast(".loop") + " - loop")
                     game.objects += Cue(game, "${game.id}/$name", listOf(), name, CustomSoundNotice.DURATION,
                                         true, true, fh, null, null,
-                                        listOf(), 0f, loops)
+                                        listOf(), 0f, loops, 0f)
                 }
 
                 if (RHRE3.outputCustomSfx) {

--- a/core/src/main/kotlin/io/github/chrislo27/rhre3/registry/datamodel/impl/Cue.kt
+++ b/core/src/main/kotlin/io/github/chrislo27/rhre3/registry/datamodel/impl/Cue.kt
@@ -17,7 +17,7 @@ open class Cue(game: Game, id: String, deprecatedIDs: List<String>, name: String
                val soundHandle: FileHandle,
                val introSound: String?, val endingSound: String?,
                override val responseIDs: List<String>,
-               val baseBpm: Float, val loops: Boolean)
+               val baseBpm: Float, val loops: Boolean, val earliness: Float)
     : Datamodel(game, id, deprecatedIDs, name), ResponseModel, DurationModel {
 
     val usesBaseBpm: Boolean
@@ -26,9 +26,6 @@ open class Cue(game: Game, id: String, deprecatedIDs: List<String>, name: String
     val sound: LazySound by lazy {
         LazySound(soundHandle)
     }
-
-    val earliness: Float
-        get() = 0f
 
     val introSoundCue: Cue?
         get() =

--- a/core/src/main/kotlin/io/github/chrislo27/rhre3/registry/json/GameToJson.kt
+++ b/core/src/main/kotlin/io/github/chrislo27/rhre3/registry/json/GameToJson.kt
@@ -37,6 +37,7 @@ fun Game.toJsonObject(starSubstitution: Boolean): GameObject {
                     it.loops = datamodel.loops
                     it.stretchable = datamodel.stretchable
                     it.responseIDs = datamodel.responseIDs.map(String::starSubstitute)
+                    it.earliness = datamodel.earliness
                 }
             }
             is Equidistant -> {

--- a/core/src/main/kotlin/io/github/chrislo27/rhre3/registry/json/NamedIDObject.kt
+++ b/core/src/main/kotlin/io/github/chrislo27/rhre3/registry/json/NamedIDObject.kt
@@ -101,6 +101,9 @@ class CueObject : NamedIDObject() {
     @JsonInclude(JsonInclude.Include.NON_DEFAULT)
     var loops: Boolean = false
 
+    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+    var earliness: Float = 0f
+
 }
 
 @JsonTypeName("equidistant")

--- a/core/src/main/kotlin/io/github/chrislo27/rhre3/screen/ExportRemixScreen.kt
+++ b/core/src/main/kotlin/io/github/chrislo27/rhre3/screen/ExportRemixScreen.kt
@@ -431,7 +431,7 @@ class ExportRemixScreen(main: RHRE3Application)
 
         try {
             // prep triggers
-            val startMs = Math.min(remix.musicStartSec.toDouble(), remix.tempos.beatsToSeconds(remix.entities.minBy { it.bounds.x }?.bounds?.x ?: 0.0f).toDouble()).toFloat() * 1000.0
+            val startMs = Math.min(remix.musicStartSec.toDouble(), remix.tempos.beatsToSeconds(remix.entities.minBy { it.getLowerUpdateableBound() }?.getLowerUpdateableBound() ?: 0.0f).toDouble()).toFloat() * 1000.0
             val endMs = endSeconds * 1000.0
             val durationMs = endMs - startMs
 

--- a/docs/JSON-object-definitions.md
+++ b/docs/JSON-object-definitions.md
@@ -204,6 +204,7 @@ Example:<br>
   "fileExtension": "ogg",
   "loops": false,
   "baseBpm": 120.0,
+  "earliness": 0.05,
 
   "introSound": "other/ID",
   "endingSound": "other/ID2",
@@ -224,12 +225,13 @@ metadata such as the duration and its editable abilities.
 | duration | number | Duration of this cue in beats |
 | stretchable | boolean? | If true, the cue can be dragged longer or shorter |
 | repitchable | boolean? | If true, the cue can have its pitch changed by the user |
-| fileExtension | string? | File extension of the cue sound file. Always use OGG Vorbis files, so don't use this field. |
+| fileExtension | string? | File extension of the cue sound file. You should generally always use OGG Vorbis files, so you shouldn't have to use this field. |
 | loops | boolean? | If true, this cue loops its sound. |
 | baseBpm | number?| If present, this cue will get repitched automatically based on the tempo. See below for more info. Must be greater than zero if present.|
 | introSound | id?| If present, will play this other sound at the start of the cue. See below for more info. |
 | endingSound | id?| If present, will play this other sound at the end of the cue. See below for more info. |
-| responseIDs| (array of IDs)? | If present, these IDs will be used for response-copying. See below for more info. |
+| responseIDs | (array of IDs)? | If present, these IDs will be used for response-copying. See below for more info. |
+| earliness | number? | If present, indicates the number of seconds **early** to play this cue. Useful for voiced cues where certain syllables start earlier. Negative values should not be used. Defaults to 0.0. |
 
 The `id` field is structured like this: `dataObjectID/lowerCamelCaseSoundFileName`.
 If the parent data object's ID is `spaceDance`, and this sound's name is `turnRight`,


### PR DESCRIPTION
### Description
Some sound effects have syllables in them, but the "beat" isn't on the first syllable. Example: "th-ree" in Shrimp Shuffle has the stress on "-ree" and not "th-".  Because of the way RHRE works, all entities are usually "updated" when the playback marker is inside the entity. Therefore, with the current system, one would have to manually move the cue backwards by a few fractions of a second to account for the timing. To remedy this, a refactor has been done to add the following:  
* The `earliness` property in `CueObject`
* The ability for all CueEntities and multipart entities to handle being updated earlier

The `earliness` property defines the number of seconds **early** to play the corresponding sound effect. Negative values (i.e.: lateness) should not be used. RSDE will have an update to add this field.